### PR TITLE
Update mmd-api-access-app-context.md

### DIFF
--- a/managed-desktop/developer/mmd-api-access-app-context.md
+++ b/managed-desktop/developer/mmd-api-access-app-context.md
@@ -64,7 +64,7 @@ In the OAuth 2.0 client credentials grant flow, you use the application ID and c
 You send an HTTP POST request to the /token identity platform endpoint to acquire an access token:
 
 ```http
-https://login.microsoftonline.com/{tenantId}/oauth2/token
+https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token
 ```
 
 | Parameter  | Condition | Description |
@@ -73,7 +73,7 @@ https://login.microsoftonline.com/{tenantId}/oauth2/token
 | client_id | Required | The application ID assigned when you registered your app. |
 | Scope | Required | Must be `https://mwaas-services-customerapi-prod.azurewebsites.net/.default` |
 | client_secret | Required | The client secret that you generated for your app in the app registration portal.|
-| grant_type | Required | Must be `client_credential`. |
+| grant_type | Required | Must be `client_credentials`. |
 
 ### Token response
 


### PR DESCRIPTION
Two changes suggested in the Token Request section:
(1) typo, change grant_type from "client_credential" to "client_credentials" (add an 's' at the end), otherwise getting error: The app requested an unsupported grant type 'client_credential';
(2) functional, change token identity endpoint from "/oauth2/token" to newer "/oauth2/v2.0/token". When using the old endpoint no roles are included in the retrieved bearer token (MmdSupport.ReadWrite is needed here), and getting error "The remote server returned an error: (401) Unauthorized" for all API calls.